### PR TITLE
内置 wx-cli，实现安装即用

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ## 功能
 
 - 图形界面：搜索、多选联系人/群聊
+- **内置 wx-cli**：安装即用，无需单独安装命令行工具
 - 自动检测微信数据目录
 - 通过 LLDB 捕获数据库密钥并解密（微信 4.x SQLCipher）
 - 导出聊天记录到本地文件夹
@@ -36,6 +37,8 @@ cd WeChatExporter
 
 - `~/Desktop/WeChatExporter.app`
 - `/Applications/WeChatExporter.app`
+
+应用已内置 `wx-cli`（`Contents/Resources/wx-cli`），**无需**再单独安装命令行工具。
 
 ### 方式二：仅编译不安装
 
@@ -69,7 +72,11 @@ Sources/WeChatExporter/
     ├── DatabaseService.swift
     ├── ContactStore.swift       # 联系人/会话列表
     ├── ChatExporter.swift       # 导出 TXT/CSV/JSON
+    ├── WxCliService.swift       # 内置 wx-cli 调用
     └── SQLiteDatabase.swift
+
+scripts/
+└── bundle_wx_cli.sh             # 构建时下载并打包 wx-cli
 ```
 
 ## 数据目录

--- a/Sources/WeChatExporter/Services/WxCliService.swift
+++ b/Sources/WeChatExporter/Services/WxCliService.swift
@@ -3,17 +3,34 @@ import Foundation
 /// 通过 wx-cli 自动检测微信路径、解密并导出，避免硬编码路径。
 final class WxCliService {
     let executable: URL
+    let isBundled: Bool
 
     init?(executable: URL? = nil) {
         if let executable, FileManager.default.isExecutableFile(atPath: executable.path) {
             self.executable = executable
+            self.isBundled = Self.isBundledExecutable(executable)
             return
         }
         guard let found = Self.locateExecutable() else { return nil }
         self.executable = found
+        self.isBundled = Self.isBundledExecutable(found)
+    }
+
+    /// 应用包内随附的 wx-cli（安装即用，无需单独安装 CLI）。
+    static func bundledExecutable() -> URL? {
+        let candidates = [
+            Bundle.main.resourceURL?.appendingPathComponent("wx-cli"),
+            Bundle.main.bundleURL.appendingPathComponent("MacOS/wx-cli"),
+        ]
+        for url in candidates.compactMap({ $0 }) where FileManager.default.isExecutableFile(atPath: url.path) {
+            return url
+        }
+        return nil
     }
 
     static func locateExecutable() -> URL? {
+        if let bundled = bundledExecutable() { return bundled }
+
         let home = FileManager.default.homeDirectoryForCurrentUser
         let candidates = [
             home.appendingPathComponent(".local/bin/wx-cli"),
@@ -24,6 +41,11 @@ final class WxCliService {
             return url
         }
         return nil
+    }
+
+    private static func isBundledExecutable(_ url: URL) -> Bool {
+        let bundleRoot = Bundle.main.bundleURL.path
+        return url.path.hasPrefix(bundleRoot + "/")
     }
 
     func statusText() async throws -> String {

--- a/Sources/WeChatExporter/ViewModels/AppViewModel.swift
+++ b/Sources/WeChatExporter/ViewModels/AppViewModel.swift
@@ -28,7 +28,7 @@ final class AppViewModel: ObservableObject {
 
         if let wxCli = WxCliService() {
             backend = .wxCli(wxCli)
-            appendLog("使用 wx-cli 自动检测微信路径")
+            appendLog(wxCli.isBundled ? "使用内置 wx-cli（即装即用）" : "使用系统 wx-cli")
             Task { await bootstrap() }
             return
         }

--- a/build_app.sh
+++ b/build_app.sh
@@ -6,6 +6,7 @@ APP_NAME="WeChatExporter"
 APP_DIR="$ROOT/${APP_NAME}.app"
 BINARY="$ROOT/.build/release/WeChatExporter"
 ICON_SRC="$HOME/WeChatExporter/assets/AppIcon.icns"
+WX_CLI_VERSION="${WX_CLI_VERSION:-v0.7.2}"
 
 echo "编译原生 macOS 应用…"
 cd "$ROOT"
@@ -14,6 +15,10 @@ swift build -c release
 mkdir -p "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Resources"
 cp "$BINARY" "$APP_DIR/Contents/MacOS/$APP_NAME"
 chmod +x "$APP_DIR/Contents/MacOS/$APP_NAME"
+
+echo "打包内置 wx-cli ${WX_CLI_VERSION}…"
+WX_CLI_VERSION="$WX_CLI_VERSION" bash "$ROOT/scripts/bundle_wx_cli.sh" "$APP_DIR/Contents/Resources"
+chmod +x "$APP_DIR/Contents/Resources/wx-cli"
 
 if [[ -f "$ICON_SRC" ]]; then
   cp "$ICON_SRC" "$APP_DIR/Contents/Resources/AppIcon.icns"

--- a/scripts/bundle_wx_cli.sh
+++ b/scripts/bundle_wx_cli.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# 下载并解压 wx-cli 到指定目录，供 WeChatExporter.app 内置使用。
+set -euo pipefail
+
+DEST_DIR="${1:?用法: bundle_wx_cli.sh <目标目录>}"
+WX_CLI_VERSION="${WX_CLI_VERSION:-v0.7.2}"
+WX_CLI_REPO="pandorafuture/wx-cli"
+ASSET="wx-cli-${WX_CLI_VERSION}-macos-arm64.tar.gz"
+URL="https://github.com/${WX_CLI_REPO}/releases/download/${WX_CLI_VERSION}/${ASSET}"
+
+mkdir -p "$DEST_DIR"
+DEST_BIN="$DEST_DIR/wx-cli"
+
+if [[ -x "$DEST_BIN" ]]; then
+  echo "wx-cli 已存在：$DEST_BIN"
+  exit 0
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "下载内置 wx-cli ${WX_CLI_VERSION}…"
+curl -fsSL --retry 3 --retry-delay 2 -o "$TMP_DIR/$ASSET" "$URL"
+
+echo "解压 wx-cli…"
+tar -xzf "$TMP_DIR/$ASSET" -C "$TMP_DIR"
+
+if [[ -f "$TMP_DIR/wx-cli" ]]; then
+  SRC="$TMP_DIR/wx-cli"
+elif [[ -f "$TMP_DIR/wx-cli/wx-cli" ]]; then
+  SRC="$TMP_DIR/wx-cli/wx-cli"
+else
+  SRC="$(find "$TMP_DIR" -type f -name wx-cli | head -1)"
+fi
+
+if [[ -z "$SRC" || ! -f "$SRC" ]]; then
+  echo "错误：未在压缩包中找到 wx-cli 可执行文件"
+  exit 1
+fi
+
+cp "$SRC" "$DEST_BIN"
+chmod +x "$DEST_BIN"
+echo "已写入：$DEST_BIN"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

将 `wx-cli` 打包进 `WeChatExporter.app`，用户安装应用后无需再单独安装命令行工具即可使用全部功能。

## Changes

- 新增 `scripts/bundle_wx_cli.sh`：构建时从 [pandorafuture/wx-cli](https://github.com/pandorafuture/wx-cli) Release 下载 macOS arm64 二进制（默认 `v0.7.2`）
- 更新 `build_app.sh`：编译完成后自动将 `wx-cli` 写入 `Contents/Resources/wx-cli`
- 更新 `WxCliService`：优先查找应用包内内置的 `wx-cli`，其次才回退到系统 PATH
- 更新启动日志：区分「内置 wx-cli（即装即用）」与「系统 wx-cli」
- 更新 README：说明内置 CLI，无需额外安装

## Usage

构建与安装流程不变：

```bash
./install.sh
```

构建产物 `WeChatExporter.app/Contents/Resources/wx-cli` 即为内置 CLI。

## Notes

- 若从源码直接 `swift run`（非 .app 包），仍会回退到原生解密后端或系统已安装的 wx-cli
- 内置 wx-cli 版本可通过环境变量 `WX_CLI_VERSION` 在构建时指定
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f378e-ac61-7458-af96-597774ae54d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f378e-ac61-7458-af96-597774ae54d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

