### PR TITLE
新增 Windows 版：WPF 图形界面 + 内置 wx-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ Package.resolved
 WeChatExporter.app/
 *.dSYM/
 
+# .NET / Windows
+windows/**/bin/
+windows/**/obj/
+windows/publish/
+windows/dist/
+
 # Xcode
 DerivedData/
 *.xcuserstate

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # WeChatExporter
 
-原生 macOS 应用，用于导出微信 Mac 版本地聊天记录。
+原生应用，用于导出微信本地聊天记录。
 
-基于 Swift + SwiftUI 构建，支持选择任意联系人或群聊，导出为 TXT / CSV / JSON 格式。
+- **macOS 版**：Swift + SwiftUI（见项目根目录）
+- **Windows 版**：.NET 8 WPF（见 [`windows/`](windows/) 目录）
+
+基于 Swift + SwiftUI（macOS）构建，支持选择任意联系人或群聊，导出为 TXT / CSV / JSON 格式。
 
 ## 功能
 
@@ -24,7 +27,9 @@
 
 ## 安装
 
-### 方式一：从源码构建
+### macOS
+
+#### 方式一：从源码构建
 
 ```bash
 git clone https://github.com/93857536-pixel/WeChatExporter.git
@@ -37,14 +42,25 @@ cd WeChatExporter
 - `~/Desktop/WeChatExporter.app`
 - `/Applications/WeChatExporter.app`
 
-### 方式二：仅编译不安装
+#### 方式二：仅编译不安装
 
 ```bash
 ./build_app.sh
 # 产物：./WeChatExporter.app
 ```
 
-## 使用
+### Windows
+
+详见 [`windows/README.md`](windows/README.md)。
+
+```powershell
+cd windows
+.\install.ps1
+```
+
+Windows 版内置 `wx.exe`，安装后无需单独安装 CLI。首次使用建议以管理员身份运行。
+
+## 使用（macOS）
 
 1. 打开 **WeChatExporter**
 2. 首次使用点击 **「准备数据」**（会通过 LLDB 重启微信并捕获密钥，随后解密数据库）
@@ -55,6 +71,8 @@ cd WeChatExporter
 若系统提示「无法验证开发者」，请 **右键 → 打开 → 确认打开**。
 
 ## 项目结构
+
+**macOS**
 
 ```
 Sources/WeChatExporter/
@@ -71,6 +89,8 @@ Sources/WeChatExporter/
     ├── ChatExporter.swift       # 导出 TXT/CSV/JSON
     └── SQLiteDatabase.swift
 ```
+
+**Windows** — 见 [`windows/README.md`](windows/README.md)
 
 ## 数据目录
 

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,100 @@
+# WeChatExporter — Windows 版
+
+原生 Windows 桌面应用，用于导出 **微信 PC 版 4.x** 本地聊天记录。
+
+基于 **.NET 8 WPF** 构建，内置 [jackwener/wx-cli](https://github.com/jackwener/wx-cli)，安装即用，无需单独安装 CLI。
+
+## 功能
+
+- 图形界面：搜索、多选联系人/群聊
+- **内置 wx-cli**：密钥扫描、数据库解密、导出一体化
+- 导出格式：**TXT / CSV / JSON**
+- 默认导出目录：`Downloads\微信聊天记录导出\`
+
+## 系统要求
+
+| 项目 | 要求 |
+|------|------|
+| 系统 | Windows 10 / 11（64 位） |
+| 运行时 | [.NET 8 Desktop Runtime](https://dotnet.microsoft.com/download/dotnet/8.0) |
+| 微信 | PC 版 4.x（已登录并同步过聊天记录） |
+| 权限 | 首次「准备数据」建议 **以管理员身份运行**（读取微信进程内存） |
+
+> **隐私说明**：本工具仅在本地运行，不会上传任何聊天数据或密钥。
+
+## 安装
+
+### 方式一：一键安装（推荐）
+
+在 PowerShell 中执行：
+
+```powershell
+cd windows
+.\install.ps1
+```
+
+安装完成后，桌面会出现 `WeChatExporter` 文件夹，内含 `WeChatExporter.exe` 与内置 `wx.exe`。
+
+### 方式二：仅构建
+
+```powershell
+cd windows
+.\build.ps1
+# 产物：windows\dist\WeChatExporter\
+```
+
+## 使用
+
+1. **右键 → 以管理员身份运行** `WeChatExporter.exe`（首次推荐）
+2. 点击 **「准备数据」**（自动扫描密钥并解密数据库）
+3. 在左侧列表搜索并选择联系人或群聊（Ctrl 多选）
+4. 点击 **「导出选中」**
+
+## 项目结构
+
+```
+windows/
+├── WeChatExporter.Windows/     # WPF 主程序
+│   ├── MainWindow.xaml           # 界面
+│   ├── ViewModels/               # 视图模型
+│   ├── Services/WxCliService.cs  # 内置 wx-cli 调用
+│   └── Models/                   # 数据模型
+├── scripts/bundle_wx_cli.ps1     # 构建时下载 wx-cli
+├── build.ps1                     # 构建脚本
+└── install.ps1                   # 安装脚本
+```
+
+## 数据目录
+
+| 用途 | 路径 |
+|------|------|
+| 微信加密数据库 | `%USERPROFILE%\Documents\xwechat_files\<账号>\db_storage\` |
+| wx-cli 配置与密钥 | `%USERPROFILE%\.wx-cli\` |
+| wx-cli 解密缓存 | `%USERPROFILE%\.wx-cli\cache\` |
+| 导出结果 | `%USERPROFILE%\Downloads\微信聊天记录导出\` |
+
+## 常见问题
+
+**提示密钥扫描失败 / init 失败**
+
+1. 确认微信 PC 版已登录并在运行
+2. 右键 **以管理员身份运行** WeChatExporter
+3. 重新点击「准备数据」
+
+**提示未找到 wx-cli**
+
+重新运行 `install.ps1` 或 `build.ps1`，确认 `wx.exe` 与 `WeChatExporter.exe` 在同一目录。
+
+**会话列表为空**
+
+先点击「准备数据」，完成后点击「刷新」。
+
+## 免责声明
+
+- 本工具仅供个人备份自己的聊天记录，请勿用于非法用途
+- 微信数据库格式可能随版本更新而变化，不保证兼容所有版本
+- 使用本工具的风险由使用者自行承担
+
+## License
+
+MIT

--- a/windows/WeChatExporter.Windows/App.xaml
+++ b/windows/WeChatExporter.Windows/App.xaml
@@ -1,0 +1,12 @@
+<Application x:Class="WeChatExporter.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:WeChatExporter"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+        <SolidColorBrush x:Key="AccentBrush" Color="#07C35F"/>
+        <SolidColorBrush x:Key="AccentSoftBrush" Color="#1A07C35F"/>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+        <local:InverseBooleanConverter x:Key="NotBool"/>
+    </Application.Resources>
+</Application>

--- a/windows/WeChatExporter.Windows/App.xaml.cs
+++ b/windows/WeChatExporter.Windows/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace WeChatExporter;
+
+public partial class App : Application
+{
+}

--- a/windows/WeChatExporter.Windows/MainWindow.xaml
+++ b/windows/WeChatExporter.Windows/MainWindow.xaml
@@ -1,0 +1,110 @@
+<Window x:Class="WeChatExporter.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="微信聊天记录导出"
+        Width="980" Height="680" MinWidth="980" MinHeight="680"
+        WindowStartupLocation="CenterScreen">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="360"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <DockPanel Grid.Column="0" Margin="16">
+            <Border DockPanel.Dock="Top" Background="#F5F5F5" CornerRadius="12" Padding="14" Margin="0,0,0,12">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <Border Background="{StaticResource AccentBrush}" CornerRadius="10" Width="48" Height="48">
+                            <TextBlock Text="💬" FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <StackPanel Margin="12,0,0,0" VerticalAlignment="Center">
+                            <TextBlock Text="导出工具" FontSize="18" FontWeight="SemiBold"/>
+                            <TextBlock Text="选择联系人后导出 TXT / CSV / JSON" Foreground="Gray" FontSize="12"/>
+                        </StackPanel>
+                    </StackPanel>
+                    <ProgressBar Height="4" IsIndeterminate="True"
+                                 Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+                </StackPanel>
+            </Border>
+
+            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,8">
+                <Button Content="准备数据" Padding="10,6" Margin="0,0,6,0"
+                        Click="PrepareData_Click" IsEnabled="{Binding IsBusy, Converter={StaticResource NotBool}}"/>
+                <Button Content="刷新" Padding="10,6" Margin="0,0,6,0"
+                        Click="Refresh_Click" IsEnabled="{Binding IsBusy, Converter={StaticResource NotBool}}"/>
+                <Button Content="导出选中" Padding="10,6"
+                        Background="{StaticResource AccentBrush}" Foreground="White"
+                        Click="Export_Click" IsEnabled="{Binding CanExport}"/>
+            </StackPanel>
+
+            <TextBox DockPanel.Dock="Top" Margin="0,0,0,8"
+                     Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                     Padding="8,6"/>
+
+            <TextBlock DockPanel.Dock="Top" Text="{Binding FilteredCountText}" Foreground="Gray" Margin="0,0,0,6"/>
+
+            <ListBox x:Name="ContactList"
+                     ItemsSource="{Binding ContactsView}"
+                     SelectionMode="Extended"
+                     SelectionChanged="ContactList_SelectionChanged">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Margin="0,4">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel>
+                                <TextBlock Text="{Binding DisplayName}" FontWeight="Medium"/>
+                                <TextBlock Text="{Binding Subtitle}" Foreground="Gray" FontSize="11"/>
+                            </StackPanel>
+                            <Border Grid.Column="1" Background="{StaticResource AccentSoftBrush}"
+                                    CornerRadius="10" Padding="8,3" VerticalAlignment="Center">
+                                <TextBlock Text="{Binding KindLabel}" FontSize="10"/>
+                            </Border>
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </DockPanel>
+
+        <ScrollViewer Grid.Column="1" Padding="20" VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <GroupBox Header="导出目录" Margin="0,0,0,16" Padding="12">
+                    <StackPanel>
+                        <TextBox Text="{Binding ExportPath, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Content="选择…" Padding="10,6" Margin="0,0,8,0" Click="ChooseFolder_Click"/>
+                            <Button Content="打开" Padding="10,6" Click="OpenFolder_Click"/>
+                        </StackPanel>
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox Header="使用说明" Margin="0,0,0,16" Padding="12">
+                    <StackPanel>
+                        <TextBlock Text="1. 首次使用点击「准备数据」（需微信 PC 版已登录）" Margin="0,2"/>
+                        <TextBlock Text="2. 若密钥扫描失败，请右键以管理员身份运行本程序" Margin="0,2"/>
+                        <TextBlock Text="3. 在左侧列表中选择一个或多个联系人（Ctrl 多选）" Margin="0,2"/>
+                        <TextBlock Text="4. 点击「导出选中」" Margin="0,2"/>
+                        <TextBlock Text="5. 默认导出目录：Downloads\微信聊天记录导出\" Foreground="Gray" Margin="0,2"/>
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox Header="日志" Padding="12">
+                    <DockPanel MinHeight="280">
+                        <TextBlock DockPanel.Dock="Top" Text="{Binding StatusText}" Foreground="Gray"
+                                   HorizontalAlignment="Right" Margin="0,0,0,8"/>
+                        <ListBox ItemsSource="{Binding Logs}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding}" FontFamily="Consolas" FontSize="11"
+                                               TextWrapping="Wrap"/>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </DockPanel>
+                </GroupBox>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Window>

--- a/windows/WeChatExporter.Windows/MainWindow.xaml.cs
+++ b/windows/WeChatExporter.Windows/MainWindow.xaml.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using WeChatExporter.Models;
+using WeChatExporter.Services;
+using WeChatExporter.ViewModels;
+
+namespace WeChatExporter;
+
+public partial class MainWindow : Window
+{
+    private readonly MainViewModel _viewModel;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        var wxCli = WxCliService.TryCreate()
+            ?? throw new InvalidOperationException(
+                "未找到 wx-cli。请重新安装应用，或确认 wx.exe 位于程序目录。");
+
+        _viewModel = new MainViewModel(wxCli);
+        DataContext = _viewModel;
+    }
+
+    private void ContactList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        _viewModel.SelectedContacts.Clear();
+        foreach (ContactItem item in ContactList.SelectedItems)
+            _viewModel.SelectedContacts.Add(item);
+        _viewModel.NotifySelectionChanged();
+    }
+
+    private async void PrepareData_Click(object sender, RoutedEventArgs e)
+        => await _viewModel.PrepareDataAsync();
+
+    private async void Refresh_Click(object sender, RoutedEventArgs e)
+        => await _viewModel.RefreshContactsAsync();
+
+    private async void Export_Click(object sender, RoutedEventArgs e)
+        => await _viewModel.ExportSelectedAsync();
+
+    private void ChooseFolder_Click(object sender, RoutedEventArgs e)
+        => _viewModel.ChooseExportFolder();
+
+    private void OpenFolder_Click(object sender, RoutedEventArgs e)
+        => _viewModel.OpenExportFolder();
+}
+
+public sealed class InverseBooleanConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is bool b ? !b : true;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is bool b ? !b : false;
+}

--- a/windows/WeChatExporter.Windows/Models/ContactItem.cs
+++ b/windows/WeChatExporter.Windows/Models/ContactItem.cs
@@ -1,0 +1,31 @@
+namespace WeChatExporter.Models;
+
+public enum ContactKind
+{
+    Friend,
+    Group,
+    Official
+}
+
+public sealed class ContactItem
+{
+    public required string Id { get; init; }
+    public required string DisplayName { get; init; }
+    public required string NickName { get; init; }
+    public required string Remark { get; init; }
+    public required ContactKind Kind { get; init; }
+    public required string LastTime { get; init; }
+    public required long LastTimestamp { get; init; }
+    public required string Summary { get; init; }
+
+    public string KindLabel => Kind switch
+    {
+        ContactKind.Group => "群聊",
+        ContactKind.Official => "公众号",
+        _ => "好友"
+    };
+
+    public string Subtitle => string.IsNullOrWhiteSpace(Summary)
+        ? LastTime
+        : $"{LastTime} · {Summary}";
+}

--- a/windows/WeChatExporter.Windows/Services/WxCliService.cs
+++ b/windows/WeChatExporter.Windows/Services/WxCliService.cs
@@ -1,0 +1,376 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using WeChatExporter.Models;
+
+namespace WeChatExporter.Services;
+
+/// <summary>
+/// 调用内置或系统 wx-cli（jackwener/wx-cli）完成密钥提取、解密与导出。
+/// </summary>
+public sealed class WxCliService
+{
+    public string ExecutablePath { get; }
+    public bool IsBundled { get; }
+
+    private WxCliService(string executablePath, bool isBundled)
+    {
+        ExecutablePath = executablePath;
+        IsBundled = isBundled;
+    }
+
+    public static WxCliService? TryCreate()
+    {
+        var path = LocateExecutable();
+        return path is null ? null : new WxCliService(path, IsBundledPath(path));
+    }
+
+    public static string? LocateExecutable()
+    {
+        var bundled = Path.Combine(AppContext.BaseDirectory, "wx.exe");
+        if (File.Exists(bundled))
+            return bundled;
+
+        var local = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".local", "bin", "wx.exe");
+        if (File.Exists(local))
+            return local;
+
+        foreach (var dir in (Environment.GetEnvironmentVariable("PATH") ?? "")
+                     .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var candidate = Path.Combine(dir.Trim(), "wx.exe");
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        return null;
+    }
+
+    private static bool IsBundledPath(string path)
+    {
+        var baseDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalized = Path.GetFullPath(path);
+        return normalized.StartsWith(baseDir, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async Task PrepareDataAsync(Action<string> log, CancellationToken cancellationToken = default)
+    {
+        log("检查 wx-cli 环境…");
+        var status = await RunAsync(["daemon", "status"], 30, log, cancellationToken);
+        var needsInit = !status.Contains("ready", StringComparison.OrdinalIgnoreCase)
+                        && !status.Contains("running", StringComparison.OrdinalIgnoreCase);
+
+        if (needsInit || !File.Exists(GetConfigPath()))
+        {
+            log("正在初始化（扫描密钥并解密数据库，约 1-3 分钟）…");
+            log("提示：若失败，请以管理员身份重新打开本程序。");
+            await RunAsync(["init", "--force"], 300, log, cancellationToken);
+        }
+        else
+        {
+            log("使用已保存的密钥与缓存");
+            await RunAsync(["init"], 180, log, cancellationToken);
+        }
+
+        log("数据准备完成");
+    }
+
+    public async Task<IReadOnlyList<ContactItem>> LoadSessionsAsync(
+        Action<string> log,
+        CancellationToken cancellationToken = default)
+    {
+        log("正在加载会话列表…");
+        var output = await RunAsync(["sessions", "--json", "--limit", "10000"], 120, log, cancellationToken);
+        var items = ParseSessions(output);
+        log($"已加载 {items.Count} 个会话");
+        return items;
+    }
+
+    public async Task<int> ExportAsync(
+        ContactItem contact,
+        string outputDir,
+        Action<string> log,
+        CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(outputDir);
+        var query = string.IsNullOrWhiteSpace(contact.DisplayName) ? contact.Id : contact.DisplayName;
+        log($"导出：{contact.DisplayName}");
+
+        var txtPath = Path.Combine(outputDir, "chat.txt");
+        var jsonPath = Path.Combine(outputDir, "chat.json");
+        var csvPath = Path.Combine(outputDir, "chat.csv");
+
+        await RunAsync([
+            "export", query,
+            "--format", "txt",
+            "-o", txtPath,
+            "--limit", "999999"
+        ], 600, log, cancellationToken);
+
+        await RunAsync([
+            "export", query,
+            "--format", "json",
+            "-o", jsonPath,
+            "--limit", "999999"
+        ], 600, log, cancellationToken);
+
+        var count = await WriteCsvFromJsonAsync(jsonPath, csvPath);
+        if (count == 0 && File.Exists(txtPath))
+            count = CountTxtMessages(txtPath);
+
+        return count;
+    }
+
+    private static string GetConfigPath()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".wx-cli", "config.json");
+    }
+
+    private async Task<string> RunAsync(
+        IReadOnlyList<string> args,
+        int timeoutSeconds,
+        Action<string> log,
+        CancellationToken cancellationToken)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = ExecutablePath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+        };
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        using var process = new Process { StartInfo = psi, EnableRaisingEvents = true };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is null) return;
+            stdout.AppendLine(e.Data);
+            log(e.Data);
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is null) return;
+            stderr.AppendLine(e.Data);
+            if (!string.IsNullOrWhiteSpace(e.Data))
+                log(e.Data);
+        };
+
+        if (!process.Start())
+            throw new InvalidOperationException("无法启动 wx-cli");
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* ignore */ }
+            throw new InvalidOperationException($"wx-cli 执行超时（>{timeoutSeconds}s）");
+        }
+
+        var combined = stdout + "\n" + stderr;
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(TrimFailureOutput(combined));
+
+        return combined.ToString();
+    }
+
+    private static string TrimFailureOutput(string text)
+    {
+        var lines = text
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(l => !l.StartsWith("note:", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        return lines.Count > 0 ? lines[^1] : "wx-cli 执行失败";
+    }
+
+    private static List<ContactItem> ParseSessions(string output)
+    {
+        var json = ExtractJson(output);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        IEnumerable<JsonElement> rows = root.ValueKind switch
+        {
+            JsonValueKind.Array => root.EnumerateArray(),
+            JsonValueKind.Object when root.TryGetProperty("results", out var results) => results.EnumerateArray(),
+            JsonValueKind.Object when root.TryGetProperty("items", out var items) => items.EnumerateArray(),
+            JsonValueKind.Object => [root],
+            _ => []
+        };
+
+        var list = new List<ContactItem>();
+        foreach (var row in rows)
+        {
+            var username = GetString(row, "username", "id", "wxid") ?? "";
+            if (string.IsNullOrWhiteSpace(username) || username == "@placeholder_foldgroup")
+                continue;
+
+            var display = GetString(row, "display", "display_name", "name", "title") ?? username;
+            display = CleanDisplayName(display, username);
+            var summary = (GetString(row, "summary", "last_message", "preview") ?? "")
+                .Replace('\n', ' ');
+            var ts = GetLong(row, "sort_timestamp", "last_timestamp", "timestamp", "time") ?? 0;
+            var chatType = GetString(row, "chat_type", "type") ?? "";
+
+            list.Add(new ContactItem
+            {
+                Id = username,
+                DisplayName = display,
+                NickName = display,
+                Remark = "",
+                Kind = ResolveKind(username, chatType),
+                LastTime = FormatTime(ts),
+                LastTimestamp = ts,
+                Summary = summary
+            });
+        }
+
+        return list.OrderByDescending(c => c.LastTimestamp).ToList();
+    }
+
+    private static ContactKind ResolveKind(string username, string chatType)
+    {
+        if (username.EndsWith("@chatroom", StringComparison.OrdinalIgnoreCase)
+            || chatType.Equals("group", StringComparison.OrdinalIgnoreCase))
+            return ContactKind.Group;
+
+        if (username.StartsWith("gh_", StringComparison.OrdinalIgnoreCase)
+            || chatType.Equals("official_account", StringComparison.OrdinalIgnoreCase))
+            return ContactKind.Official;
+
+        return ContactKind.Friend;
+    }
+
+    private static string CleanDisplayName(string raw, string username)
+    {
+        var suffixes = new[] { $"（{username}）", $"({username})" };
+        foreach (var suffix in suffixes)
+        {
+            var idx = raw.IndexOf(suffix, StringComparison.Ordinal);
+            if (idx >= 0)
+                return raw[..idx].Trim();
+        }
+        return raw.Trim();
+    }
+
+    private static string FormatTime(long ts)
+    {
+        if (ts <= 0) return "";
+        var seconds = ts > 9999999999 ? ts / 1000 : ts;
+        var dt = DateTimeOffset.FromUnixTimeSeconds(seconds).ToOffset(TimeSpan.FromHours(8));
+        return dt.ToString("yyyy-MM-dd HH:mm:ss");
+    }
+
+    private static string ExtractJson(string output)
+    {
+        var startObj = output.IndexOf('{');
+        var startArr = output.IndexOf('[');
+        int start;
+        char endChar;
+        if (startObj >= 0 && (startArr < 0 || startObj < startArr))
+        {
+            start = startObj;
+            endChar = '}';
+        }
+        else if (startArr >= 0)
+        {
+            start = startArr;
+            endChar = ']';
+        }
+        else
+        {
+            throw new InvalidOperationException("wx-cli 返回的数据格式无效");
+        }
+
+        var end = output.LastIndexOf(endChar);
+        if (end < start)
+            throw new InvalidOperationException("wx-cli 返回的数据格式无效");
+
+        return output[start..(end + 1)];
+    }
+
+    private static string? GetString(JsonElement el, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (el.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String)
+                return prop.GetString();
+        }
+        return null;
+    }
+
+    private static long? GetLong(JsonElement el, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (!el.TryGetProperty(name, out var prop)) continue;
+            if (prop.ValueKind == JsonValueKind.Number && prop.TryGetInt64(out var n))
+                return n;
+            if (prop.ValueKind == JsonValueKind.String && long.TryParse(prop.GetString(), out var parsed))
+                return parsed;
+        }
+        return null;
+    }
+
+    private static async Task<int> WriteCsvFromJsonAsync(string jsonPath, string csvPath)
+    {
+        if (!File.Exists(jsonPath))
+            return 0;
+
+        var json = await File.ReadAllTextAsync(jsonPath);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        IEnumerable<JsonElement> messages = root.ValueKind switch
+        {
+            JsonValueKind.Array => root.EnumerateArray(),
+            JsonValueKind.Object when root.TryGetProperty("results", out var results) => results.EnumerateArray(),
+            JsonValueKind.Object when root.TryGetProperty("messages", out var messagesProp) => messagesProp.EnumerateArray(),
+            _ => []
+        };
+
+        var rows = messages.ToList();
+        if (rows.Count == 0)
+            return 0;
+
+        var sb = new StringBuilder();
+        sb.Append('\uFEFF');
+        sb.AppendLine("时间,发送者,类型,内容");
+
+        foreach (var msg in rows)
+        {
+            var time = GetString(msg, "time", "timestamp_str") ?? FormatTime(GetLong(msg, "timestamp", "create_time") ?? 0);
+            var sender = GetString(msg, "sender", "sender_display", "from") ?? "";
+            var type = GetString(msg, "type", "msg_type", "type_name") ?? "";
+            var content = GetString(msg, "content", "text", "message") ?? "";
+            content = content.Replace("\"", "\"\"");
+            sb.AppendLine($"\"{time}\",\"{sender}\",\"{type}\",\"{content}\"");
+        }
+
+        await File.WriteAllTextAsync(csvPath, sb.ToString(), Encoding.UTF8);
+        return rows.Count;
+    }
+
+    private static int CountTxtMessages(string txtPath)
+    {
+        return File.ReadLines(txtPath).Count(line => line.StartsWith('['));
+    }
+}

--- a/windows/WeChatExporter.Windows/ViewModels/MainViewModel.cs
+++ b/windows/WeChatExporter.Windows/ViewModels/MainViewModel.cs
@@ -1,0 +1,279 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Data;
+using Microsoft.Win32;
+using WeChatExporter.Models;
+using WeChatExporter.Services;
+
+namespace WeChatExporter.ViewModels;
+
+public sealed class MainViewModel : INotifyPropertyChanged
+{
+    private readonly WxCliService _wxCli;
+    private string _searchText = "";
+    private string _exportPath;
+    private string _statusText = "就绪";
+    private bool _isBusy;
+    private string? _alertMessage;
+
+    public MainViewModel(WxCliService wxCli)
+    {
+        _wxCli = wxCli;
+        _exportPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Downloads", "微信聊天记录导出");
+        Contacts = [];
+        Logs = [];
+        ContactsView = CollectionViewSource.GetDefaultView(Contacts);
+        ContactsView.Filter = FilterContact;
+        AppendLog(wxCli.IsBundled ? "使用内置 wx-cli（即装即用）" : "使用系统 wx-cli");
+        _ = BootstrapAsync();
+    }
+
+    public ObservableCollection<ContactItem> Contacts { get; }
+    public ICollectionView ContactsView { get; }
+    public ObservableCollection<ContactItem> SelectedContacts { get; } = [];
+    public ObservableCollection<string> Logs { get; }
+
+    public string SearchText
+    {
+        get => _searchText;
+        set
+        {
+            if (_searchText == value) return;
+            _searchText = value;
+            OnPropertyChanged();
+            ContactsView.Refresh();
+            OnPropertyChanged(nameof(FilteredCountText));
+        }
+    }
+
+    public string ExportPath
+    {
+        get => _exportPath;
+        set
+        {
+            if (_exportPath == value) return;
+            _exportPath = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string StatusText
+    {
+        get => _statusText;
+        private set
+        {
+            if (_statusText == value) return;
+            _statusText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            if (_isBusy == value) return;
+            _isBusy = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(CanExport));
+        }
+    }
+
+    public bool CanExport => !IsBusy && SelectedContacts.Count > 0;
+
+    public string? AlertMessage
+    {
+        get => _alertMessage;
+        private set
+        {
+            _alertMessage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string FilteredCountText => $"显示 {ContactsView.Cast<object>().Count()} / {Contacts.Count} 个会话";
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private bool FilterContact(object obj)
+    {
+        if (obj is not ContactItem contact) return false;
+        var q = SearchText.Trim();
+        if (string.IsNullOrEmpty(q)) return true;
+        return $"{contact.DisplayName} {contact.NickName} {contact.Remark} {contact.Id} {contact.Summary}"
+            .Contains(q, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public void NotifySelectionChanged()
+    {
+        OnPropertyChanged(nameof(CanExport));
+    }
+
+    public async Task PrepareDataAsync()
+    {
+        if (IsBusy) return;
+        IsBusy = true;
+        StatusText = "准备数据中…";
+        try
+        {
+            AppendLog("开始准备数据…");
+            await _wxCli.PrepareDataAsync(AppendLog);
+            await RefreshContactsAsync();
+            ShowAlert("数据准备完成，现在可以导出聊天记录了。");
+        }
+        catch (Exception ex)
+        {
+            ShowError(ex.Message);
+        }
+        finally
+        {
+            IsBusy = false;
+            StatusText = "就绪";
+        }
+    }
+
+    public async Task RefreshContactsAsync()
+    {
+        if (IsBusy) return;
+        IsBusy = true;
+        StatusText = "加载会话…";
+        try
+        {
+            var items = await _wxCli.LoadSessionsAsync(AppendLog);
+            Contacts.Clear();
+            foreach (var item in items)
+                Contacts.Add(item);
+            ContactsView.Refresh();
+            OnPropertyChanged(nameof(FilteredCountText));
+            StatusText = FilteredCountText;
+        }
+        catch (Exception ex)
+        {
+            ShowError(ex.Message);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    public async Task ExportSelectedAsync()
+    {
+        if (IsBusy) return;
+        if (SelectedContacts.Count == 0)
+        {
+            ShowError("请先在列表中选择联系人或群聊。");
+            return;
+        }
+
+        IsBusy = true;
+        StatusText = "导出中…";
+        var summary = new List<string>();
+        try
+        {
+            Directory.CreateDirectory(ExportPath);
+            foreach (var contact in SelectedContacts.ToList())
+            {
+                var safeName = contact.DisplayName.Replace('/', '_');
+                var outDir = Path.Combine(ExportPath, safeName);
+                var count = await _wxCli.ExportAsync(contact, outDir, AppendLog);
+                summary.Add($"• {contact.DisplayName}：{count} 条");
+            }
+
+            ShowAlert($"已导出 {SelectedContacts.Count} 个会话到：\n{ExportPath}\n\n{string.Join('\n', summary)}");
+        }
+        catch (Exception ex)
+        {
+            ShowError(ex.Message);
+        }
+        finally
+        {
+            IsBusy = false;
+            StatusText = "就绪";
+        }
+    }
+
+    public void ChooseExportFolder()
+    {
+        var dialog = new OpenFolderDialog
+        {
+            Title = "选择导出目录",
+            InitialDirectory = Directory.Exists(ExportPath) ? ExportPath : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+        };
+        if (dialog.ShowDialog() == true)
+            ExportPath = dialog.FolderName;
+    }
+
+    public void OpenExportFolder()
+    {
+        Directory.CreateDirectory(ExportPath);
+        ProcessHelper.OpenFolder(ExportPath);
+    }
+
+    private async Task BootstrapAsync()
+    {
+        AppendLog("正在自动加载会话列表…");
+        try
+        {
+            var items = await _wxCli.LoadSessionsAsync(AppendLog);
+            Contacts.Clear();
+            foreach (var item in items)
+                Contacts.Add(item);
+            ContactsView.Refresh();
+            OnPropertyChanged(nameof(FilteredCountText));
+            StatusText = FilteredCountText;
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"自动加载失败：{ex.Message}");
+            AppendLog("首次使用请点击「准备数据」。");
+        }
+    }
+
+    private void AppendLog(string message)
+    {
+        var line = message.Trim();
+        if (string.IsNullOrEmpty(line)) return;
+
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            Logs.Add(line);
+            while (Logs.Count > 300)
+                Logs.RemoveAt(0);
+        });
+    }
+
+    private void ShowAlert(string message)
+    {
+        AlertMessage = message;
+        MessageBox.Show(message, "提示", MessageBoxButton.OK, MessageBoxImage.Information);
+    }
+
+    private void ShowError(string message)
+    {
+        AppendLog($"错误：{message}");
+        AlertMessage = message;
+        MessageBox.Show(message, "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+internal static class ProcessHelper
+{
+    public static void OpenFolder(string path)
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = path,
+            UseShellExecute = true
+        });
+    }
+}

--- a/windows/WeChatExporter.Windows/WeChatExporter.Windows.csproj
+++ b/windows/WeChatExporter.Windows/WeChatExporter.Windows.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>WeChatExporter</AssemblyName>
+    <RootNamespace>WeChatExporter</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Version>1.0.0</Version>
+    <Company>WeChatExporter</Company>
+    <Product>微信聊天记录导出</Product>
+    <Description>Windows 版微信聊天记录导出工具</Description>
+  </PropertyGroup>
+</Project>

--- a/windows/WeChatExporter.Windows/app.manifest
+++ b/windows/WeChatExporter.Windows/app.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="WeChatExporter.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- 密钥扫描需要读取微信进程内存，建议以管理员身份运行 -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -1,0 +1,30 @@
+# 构建 Windows 版 WeChatExporter（含内置 wx-cli）
+param(
+    [string]$WxCliVersion = "v0.3.0",
+    [string]$Configuration = "Release"
+)
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent $PSScriptRoot
+$Project = Join-Path $Root "WeChatExporter.Windows"
+$OutDir = Join-Path $Root "publish"
+$DistDir = Join-Path $Root "dist\WeChatExporter"
+
+Write-Host "编译 Windows 应用…"
+dotnet publish $Project `
+    -c $Configuration `
+    -r win-x64 `
+    --self-contained false `
+    -o $OutDir `
+    /p:PublishSingleFile=false
+
+Write-Host "打包内置 wx-cli $WxCliVersion …"
+& (Join-Path $Root "scripts\bundle_wx_cli.ps1") -DestDir $OutDir -WxCliVersion $WxCliVersion
+
+if (Test-Path $DistDir) { Remove-Item $DistDir -Recurse -Force }
+New-Item -ItemType Directory -Force -Path $DistDir | Out-Null
+Copy-Item (Join-Path $OutDir "*") $DistDir -Recurse -Force
+
+Write-Host ""
+Write-Host "完成：$DistDir"
+Write-Host "运行：$DistDir\WeChatExporter.exe"

--- a/windows/install.ps1
+++ b/windows/install.ps1
@@ -1,0 +1,25 @@
+# 构建并安装到桌面与开始菜单
+param(
+    [string]$WxCliVersion = "v0.3.0"
+)
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent $PSScriptRoot
+
+& (Join-Path $Root "build.ps1") -WxCliVersion $WxCliVersion
+
+$Src = Join-Path $Root "dist\WeChatExporter"
+$Desktop = Join-Path ([Environment]::GetFolderPath("Desktop")) "WeChatExporter"
+$Programs = Join-Path ([Environment]::GetFolderPath("StartMenu")) "Programs\WeChatExporter"
+
+foreach ($Target in @($Desktop, $Programs)) {
+    if (Test-Path $Target) { Remove-Item $Target -Recurse -Force }
+    Copy-Item $Src $Target -Recurse -Force
+}
+
+Write-Host ""
+Write-Host "Windows 版已安装到："
+Write-Host "  $Desktop"
+Write-Host "  $Programs"
+Write-Host ""
+Write-Host "首次使用建议右键 WeChatExporter.exe → 以管理员身份运行"

--- a/windows/scripts/bundle_wx_cli.ps1
+++ b/windows/scripts/bundle_wx_cli.ps1
@@ -1,0 +1,27 @@
+# 下载 jackwener/wx-cli Windows 二进制到指定目录
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DestDir,
+    [string]$WxCliVersion = "v0.3.0"
+)
+
+$ErrorActionPreference = "Stop"
+$DestBin = Join-Path $DestDir "wx.exe"
+
+if (Test-Path $DestBin) {
+    Write-Host "wx.exe 已存在：$DestBin"
+    exit 0
+}
+
+$Asset = "wx-windows-x86_64.exe"
+$Url = "https://github.com/jackwener/wx-cli/releases/download/$WxCliVersion/$Asset"
+$Tmp = Join-Path $env:TEMP "wx-cli-$WxCliVersion.exe"
+
+Write-Host "下载内置 wx-cli $WxCliVersion …"
+Invoke-WebRequest -Uri $Url -OutFile $Tmp -UseBasicParsing
+
+New-Item -ItemType Directory -Force -Path $DestDir | Out-Null
+Copy-Item $Tmp $DestBin -Force
+Remove-Item $Tmp -Force -ErrorAction SilentlyContinue
+
+Write-Host "已写入：$DestBin"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

新增 **Windows 版**微信聊天记录导出工具，界面与流程与 macOS 版对齐，并内置 `wx-cli`，实现安装即用。

## Changes

- 新增 `windows/WeChatExporter.Windows/` — .NET 8 WPF 图形界面
- 新增 `WxCliService` — 调用内置 [jackwener/wx-cli](https://github.com/jackwener/wx-cli) 完成初始化、会话列表、导出
- 新增构建脚本：
  - `windows/scripts/bundle_wx_cli.ps1` — 下载 Windows 版 wx-cli
  - `windows/build.ps1` — 编译并打包到 `dist/WeChatExporter/`
  - `windows/install.ps1` — 安装到桌面与开始菜单
- 更新根目录 README，说明双平台支持

## Windows 使用方式

```powershell
cd windows
.\install.ps1
```

产物目录包含 `WeChatExporter.exe` 与内置 `wx.exe`，无需单独安装 CLI。

## 功能对照

| 功能 | macOS | Windows |
|------|-------|---------|
| 图形界面 | SwiftUI | WPF |
| 内置 CLI | pandorafuture/wx-cli | jackwener/wx-cli |
| 导出格式 | TXT / CSV / JSON | TXT / CSV / JSON |
| 首次准备数据 | LLDB 密钥捕获 | 内存扫描（建议管理员运行） |

## Notes

- 需要安装 [.NET 8 Desktop Runtime](https://dotnet.microsoft.com/download/dotnet/8.0)
- 首次「准备数据」建议以管理员身份运行（读取微信进程内存）
- 微信 PC 版需 4.x 且已登录
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f378e-ac61-7458-af96-597774ae54d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f378e-ac61-7458-af96-597774ae54d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

