### PR TITLE
fix(windows): EmojiExporter 编译修复

### DIFF
--- a/windows/WeChatExporter.Windows/Services/EmojiExporter.cs
+++ b/windows/WeChatExporter.Windows/Services/EmojiExporter.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.RegularExpressions;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
修复 Windows 版 EmojiExporter 缺少 `using System.Net.Http;` 导致 CI 编译失败。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f378e-ac61-7458-af96-597774ae54d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f378e-ac61-7458-af96-597774ae54d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

