### PR TITLE
美化单文件 HTML 导出界面（DMG 深空霓虹风格）v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## [2.5.1] - 2026-07-08
+
+### Changed
+- 单文件 HTML 导出界面美化：深空霓虹 HUD 风格，与 macOS DMG 安装界面视觉一致（玻璃拟态消息卡片、星点/网格背景、青紫霓虹标题与媒体光晕）
+
 ## [2.5.0] - 2026-07-08
 
 ### Changed

--- a/Sources/WeChatExporter/Services/SingleFileExporter.swift
+++ b/Sources/WeChatExporter/Services/SingleFileExporter.swift
@@ -42,32 +42,34 @@ enum SingleFileExporter {
           <meta name="viewport" content="width=device-width, initial-scale=1"/>
           <title>\(title)</title>
           <style>
-            * { box-sizing: border-box; }
-            body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", sans-serif; margin: 0; background: #ebebeb; color: #111; }
-            header { background: linear-gradient(135deg, #07c160, #06ad56); color: #fff; padding: 20px 24px; }
-            header h1 { margin: 0 0 6px; font-size: 22px; }
-            header p { margin: 0; opacity: .92; font-size: 13px; }
-            main { max-width: 860px; margin: 0 auto; padding: 20px 16px 48px; }
-            .msg { background: #fff; border-radius: 10px; padding: 12px 14px; margin-bottom: 12px; box-shadow: 0 1px 2px rgba(0,0,0,.06); }
-            .meta { font-size: 12px; color: #666; margin-bottom: 6px; }
-            .sender { font-weight: 600; color: #07c160; }
-            .type { color: #999; margin-left: 8px; }
-            .text { white-space: pre-wrap; word-break: break-word; line-height: 1.55; }
-            .media { margin-top: 10px; }
-            .media img { max-width: min(100%, 420px); border-radius: 8px; display: block; }
-            .media video, .media audio { max-width: 100%; margin-top: 6px; display: block; }
-            footer { text-align: center; color: #999; font-size: 12px; padding: 24px; }
+            \(exportStyles)
           </style>
         </head>
         <body>
+          <div class="bg-scene" aria-hidden="true">
+            <div class="aurora aurora-a"></div>
+            <div class="aurora aurora-b"></div>
+            <div class="aurora aurora-c"></div>
+            <div class="grid-floor"></div>
+          </div>
           <header>
+            <div class="header-glow"></div>
+            <p class="eyebrow">WeChatExporter · 单文件导出</p>
             <h1>\(title)</h1>
-            <p>共 \(rows.count) 条消息 · 单文件导出（媒体已内嵌）· \(stamp)</p>
+            <div class="stats">
+              <span class="pill pill-cyan">\(rows.count) 条消息</span>
+              <span class="pill pill-purple">媒体已内嵌</span>
+              <span class="pill pill-muted">\(stamp)</span>
+            </div>
           </header>
           <main>
         \(body)
           </main>
-          <footer>由 WeChatExporter 导出</footer>
+          <footer>
+            <span class="footer-brand">WeChatExporter</span>
+            <span class="footer-dot">·</span>
+            <span>深空霓虹主题 · 浏览器离线可阅</span>
+          </footer>
         </body>
         </html>
         """
@@ -78,6 +80,276 @@ enum SingleFileExporter {
     }
 
     // MARK: - Rendering
+
+    /// 与 DMG 安装界面一致的深空霓虹 HUD 样式（青 #00f5ff · 紫 #7b61ff · 品红 #ff4dd2）
+    private static let exportStyles = """
+    :root {
+      --cyan: #00f5ff;
+      --purple: #7b61ff;
+      --magenta: #ff4dd2;
+      --green: #07ffa0;
+      --text: #f0f8ff;
+      --subtext: #8caad2;
+      --glass: rgba(12, 20, 48, 0.78);
+      --glass-strong: rgba(8, 14, 36, 0.92);
+      --line: rgba(0, 245, 255, 0.22);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", sans-serif;
+      color: var(--text);
+      background: linear-gradient(145deg, #080a20 0%, #120830 38%, #06122a 72%, #1c0626 100%);
+      background-attachment: fixed;
+      position: relative;
+      overflow-x: hidden;
+    }
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 0;
+      opacity: 0.55;
+      background-image:
+        radial-gradient(1px 1px at 8% 14%, rgba(240,248,255,0.95) 50%, transparent 51%),
+        radial-gradient(1px 1px at 22% 38%, rgba(0,245,255,0.85) 50%, transparent 51%),
+        radial-gradient(1.5px 1.5px at 35% 8%, rgba(123,97,255,0.9) 50%, transparent 51%),
+        radial-gradient(1px 1px at 48% 62%, rgba(240,248,255,0.75) 50%, transparent 51%),
+        radial-gradient(1px 1px at 61% 24%, rgba(0,245,255,0.7) 50%, transparent 51%),
+        radial-gradient(1.5px 1.5px at 74% 72%, rgba(255,77,210,0.8) 50%, transparent 51%),
+        radial-gradient(1px 1px at 86% 18%, rgba(240,248,255,0.8) 50%, transparent 51%),
+        radial-gradient(1px 1px at 92% 48%, rgba(123,97,255,0.75) 50%, transparent 51%),
+        radial-gradient(2px 2px at 16% 82%, rgba(0,245,255,0.65) 50%, transparent 51%),
+        radial-gradient(1px 1px at 54% 88%, rgba(240,248,255,0.7) 50%, transparent 51%);
+    }
+    .bg-scene { position: fixed; inset: 0; pointer-events: none; z-index: 0; overflow: hidden; }
+    .aurora {
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(72px);
+      opacity: 0.42;
+      animation: drift 18s ease-in-out infinite alternate;
+    }
+    .aurora-a {
+      width: 420px; height: 180px;
+      top: -40px; left: 12%;
+      background: radial-gradient(circle, rgba(0,180,255,0.55), transparent 70%);
+    }
+    .aurora-b {
+      width: 380px; height: 160px;
+      top: 60px; right: 8%;
+      background: radial-gradient(circle, rgba(140,60,255,0.5), transparent 70%);
+      animation-delay: -6s;
+    }
+    .aurora-c {
+      width: 500px; height: 200px;
+      bottom: 18%; left: 28%;
+      background: radial-gradient(circle, rgba(255,60,200,0.35), transparent 70%);
+      animation-delay: -12s;
+    }
+    .grid-floor {
+      position: absolute;
+      left: 0; right: 0; bottom: 0;
+      height: 42vh;
+      background:
+        linear-gradient(to bottom, transparent 0%, rgba(0,245,255,0.04) 100%),
+        repeating-linear-gradient(90deg, transparent, transparent 39px, rgba(0,245,255,0.06) 39px, rgba(0,245,255,0.06) 40px),
+        repeating-linear-gradient(0deg, transparent, transparent 13px, rgba(123,97,255,0.05) 13px, rgba(123,97,255,0.05) 14px);
+      transform: perspective(480px) rotateX(62deg);
+      transform-origin: center bottom;
+      mask-image: linear-gradient(to top, rgba(0,0,0,0.55), transparent);
+      opacity: 0.35;
+    }
+    @keyframes drift {
+      from { transform: translate3d(-12px, 0, 0) scale(1); }
+      to { transform: translate3d(18px, 14px, 0) scale(1.06); }
+    }
+    header, main, footer { position: relative; z-index: 1; }
+    header {
+      padding: 32px 24px 28px;
+      background: linear-gradient(180deg, rgba(12,20,48,0.88), rgba(8,14,36,0.72));
+      backdrop-filter: blur(18px) saturate(140%);
+      -webkit-backdrop-filter: blur(18px) saturate(140%);
+      border-bottom: 1px solid var(--line);
+      box-shadow: 0 12px 40px rgba(0,0,0,0.35), inset 0 1px 0 rgba(255,255,255,0.06);
+    }
+    .header-glow {
+      position: absolute;
+      top: 0; left: 50%;
+      width: min(680px, 90vw);
+      height: 2px;
+      transform: translateX(-50%);
+      background: linear-gradient(90deg, transparent, var(--cyan), var(--purple), var(--magenta), transparent);
+      box-shadow: 0 0 24px rgba(0,245,255,0.55);
+    }
+    .eyebrow {
+      margin: 0 0 10px;
+      font-size: 11px;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      color: var(--subtext);
+    }
+    header h1 {
+      margin: 0 0 16px;
+      font-size: clamp(24px, 4vw, 34px);
+      font-weight: 700;
+      line-height: 1.2;
+      background: linear-gradient(92deg, var(--cyan) 0%, #9ae8ff 35%, var(--purple) 68%, var(--magenta) 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+      filter: drop-shadow(0 0 18px rgba(0,245,255,0.35));
+    }
+    .stats { display: flex; flex-wrap: wrap; gap: 8px; }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 5px 12px;
+      border-radius: 999px;
+      font-size: 12px;
+      letter-spacing: 0.02em;
+      border: 1px solid transparent;
+    }
+    .pill-cyan {
+      color: var(--cyan);
+      background: rgba(0,245,255,0.1);
+      border-color: rgba(0,245,255,0.35);
+      box-shadow: 0 0 16px rgba(0,245,255,0.18);
+    }
+    .pill-purple {
+      color: #c4b5ff;
+      background: rgba(123,97,255,0.14);
+      border-color: rgba(123,97,255,0.38);
+      box-shadow: 0 0 16px rgba(123,97,255,0.18);
+    }
+    .pill-muted {
+      color: var(--subtext);
+      background: rgba(140,170,210,0.08);
+      border-color: rgba(140,170,210,0.22);
+    }
+    main {
+      max-width: 880px;
+      margin: 0 auto;
+      padding: 28px 16px 56px;
+    }
+    .msg {
+      position: relative;
+      background: var(--glass);
+      backdrop-filter: blur(14px) saturate(130%);
+      -webkit-backdrop-filter: blur(14px) saturate(130%);
+      border: 1px solid rgba(123,97,255,0.28);
+      border-radius: 16px;
+      padding: 16px 18px 18px;
+      margin-bottom: 14px;
+      box-shadow:
+        0 8px 32px rgba(0,0,0,0.32),
+        inset 0 1px 0 rgba(255,255,255,0.05),
+        0 0 24px rgba(123,97,255,0.08);
+      transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+    }
+    .msg::before {
+      content: "";
+      position: absolute;
+      top: 12px; left: 12px;
+      width: 18px; height: 18px;
+      border-top: 2px solid rgba(0,245,255,0.55);
+      border-left: 2px solid rgba(0,245,255,0.55);
+      border-radius: 4px 0 0 0;
+      pointer-events: none;
+    }
+    .msg::after {
+      content: "";
+      position: absolute;
+      bottom: 12px; right: 12px;
+      width: 18px; height: 18px;
+      border-bottom: 2px solid rgba(123,97,255,0.45);
+      border-right: 2px solid rgba(123,97,255,0.45);
+      border-radius: 0 0 4px 0;
+      pointer-events: none;
+    }
+    .msg:hover {
+      border-color: rgba(0,245,255,0.42);
+      box-shadow:
+        0 10px 36px rgba(0,0,0,0.38),
+        0 0 28px rgba(0,245,255,0.12),
+        inset 0 1px 0 rgba(255,255,255,0.07);
+      transform: translateY(-1px);
+    }
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 10px;
+      font-size: 12px;
+    }
+    .sender {
+      font-weight: 600;
+      color: var(--cyan);
+      text-shadow: 0 0 10px rgba(0,245,255,0.45);
+    }
+    .type {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 9px;
+      border-radius: 999px;
+      font-size: 11px;
+      color: #d5c8ff;
+      background: rgba(123,97,255,0.18);
+      border: 1px solid rgba(123,97,255,0.42);
+      box-shadow: 0 0 12px rgba(123,97,255,0.2);
+    }
+    .time {
+      color: var(--subtext);
+      margin-left: auto;
+      font-variant-numeric: tabular-nums;
+    }
+    .text {
+      white-space: pre-wrap;
+      word-break: break-word;
+      line-height: 1.65;
+      color: rgba(240,248,255,0.94);
+    }
+    .media { margin-top: 12px; }
+    .media img {
+      max-width: min(100%, 440px);
+      border-radius: 12px;
+      display: block;
+      border: 1px solid rgba(0,245,255,0.32);
+      box-shadow: 0 0 24px rgba(0,245,255,0.18), 0 8px 24px rgba(0,0,0,0.35);
+    }
+    .media video, .media audio {
+      max-width: 100%;
+      margin-top: 8px;
+      display: block;
+      border-radius: 12px;
+      border: 1px solid rgba(123,97,255,0.28);
+      box-shadow: 0 0 20px rgba(123,97,255,0.15);
+      background: var(--glass-strong);
+    }
+    footer {
+      text-align: center;
+      color: var(--subtext);
+      font-size: 12px;
+      padding: 28px 16px 36px;
+      border-top: 1px solid rgba(123,97,255,0.15);
+      background: linear-gradient(180deg, transparent, rgba(8,14,36,0.55));
+    }
+    .footer-brand {
+      color: var(--cyan);
+      font-weight: 600;
+      text-shadow: 0 0 10px rgba(0,245,255,0.35);
+    }
+    .footer-dot { margin: 0 8px; opacity: 0.5; }
+    @media (max-width: 640px) {
+      header { padding: 24px 16px 22px; }
+      .time { margin-left: 0; width: 100%; }
+      .msg { padding: 14px 14px 16px; }
+    }
+    """
 
     private static func renderMessage(_ row: MessageRow, sourceDir: URL, embedded: inout Set<String>) -> String {
         var mediaHTML = ""
@@ -93,7 +365,11 @@ enum SingleFileExporter {
 
         return """
             <article class="msg">
-              <div class="meta"><span class="sender">\(escapeHTML(row.sender))</span><span class="type">\(escapeHTML(row.type))</span> · \(escapeHTML(row.time))</div>
+              <div class="meta">
+                <span class="sender">\(escapeHTML(row.sender))</span>
+                <span class="type">\(escapeHTML(row.type))</span>
+                <span class="time">\(escapeHTML(row.time))</span>
+              </div>
               \(showText ? "<div class=\"text\">\(content)</div>" : "")
               \(mediaHTML.isEmpty ? "" : "<div class=\"media\">\(mediaHTML)</div>")
             </article>
@@ -117,7 +393,11 @@ enum SingleFileExporter {
             guard let block = embedMedia(relativePath: rel, sourceDir: sourceDir) else { continue }
             html += """
                 <article class="msg">
-                  <div class="meta"><span class="sender">媒体附件</span> · \(escapeHTML(fileURL.lastPathComponent))</div>
+                  <div class="meta">
+                    <span class="sender">媒体附件</span>
+                    <span class="type">文件</span>
+                    <span class="time">\(escapeHTML(fileURL.lastPathComponent))</span>
+                  </div>
                   <div class="media">\(block)</div>
                 </article>
 

--- a/build_app.sh
+++ b/build_app.sh
@@ -8,7 +8,7 @@ BINARY="$ROOT/.build/release/WeChatExporter"
 ICON_SRC="$ROOT/assets/AppIcon.icns"
 ICON_PNG="$ROOT/assets/AppIcon.png"
 WX_CLI_VERSION="${WX_CLI_VERSION:-v0.7.2}"
-APP_VERSION="${APP_VERSION:-2.5.0}"
+APP_VERSION="${APP_VERSION:-2.5.1}"
 APP_BUILD="${APP_BUILD:-15}"
 
 echo "编译原生 macOS 应用…"

--- a/windows/WeChatExporter.Windows/Services/SingleFileExporter.cs
+++ b/windows/WeChatExporter.Windows/Services/SingleFileExporter.cs
@@ -37,24 +37,65 @@ internal static class SingleFileExporter
         var html = new StringBuilder();
         html.Append("<!DOCTYPE html><html lang=\"zh-CN\"><head><meta charset=\"utf-8\"/>");
         html.Append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"/>");
-        html.Append($"<title>{title}</title><style>");
-        html.Append("*{box-sizing:border-box}body{font-family:\"Segoe UI\",\"PingFang SC\",\"Microsoft YaHei\",sans-serif;margin:0;background:#ebebeb;color:#111}");
-        html.Append("header{background:linear-gradient(135deg,#07c160,#06ad56);color:#fff;padding:20px 24px}");
-        html.Append("header h1{margin:0 0 6px;font-size:22px}header p{margin:0;opacity:.92;font-size:13px}");
-        html.Append("main{max-width:860px;margin:0 auto;padding:20px 16px 48px}");
-        html.Append(".msg{background:#fff;border-radius:10px;padding:12px 14px;margin-bottom:12px;box-shadow:0 1px 2px rgba(0,0,0,.06)}");
-        html.Append(".meta{font-size:12px;color:#666;margin-bottom:6px}.sender{font-weight:600;color:#07c160}");
-        html.Append(".type{color:#999;margin-left:8px}.text{white-space:pre-wrap;word-break:break-word;line-height:1.55}");
-        html.Append(".media{margin-top:10px}.media img{max-width:min(100%,420px);border-radius:8px;display:block}");
-        html.Append(".media video,.media audio{max-width:100%;margin-top:6px;display:block}");
-        html.Append("footer{text-align:center;color:#999;font-size:12px;padding:24px}</style></head><body>");
-        html.Append($"<header><h1>{title}</h1><p>共 {rows.Count} 条消息 · 单文件导出（媒体已内嵌）· {stamp}</p></header><main>");
+        html.Append($"<title>{title}</title><style>{ExportStyles}</style></head><body>");
+        html.Append("<div class=\"bg-scene\" aria-hidden=\"true\">");
+        html.Append("<div class=\"aurora aurora-a\"></div><div class=\"aurora aurora-b\"></div><div class=\"aurora aurora-c\"></div>");
+        html.Append("<div class=\"grid-floor\"></div></div>");
+        html.Append("<header><div class=\"header-glow\"></div>");
+        html.Append("<p class=\"eyebrow\">WeChatExporter · 单文件导出</p>");
+        html.Append($"<h1>{title}</h1><div class=\"stats\">");
+        html.Append($"<span class=\"pill pill-cyan\">{rows.Count} 条消息</span>");
+        html.Append("<span class=\"pill pill-purple\">媒体已内嵌</span>");
+        html.Append($"<span class=\"pill pill-muted\">{stamp}</span></div></header><main>");
         html.Append(body);
-        html.Append("</main><footer>由 WeChatExporter 导出</footer></body></html>");
+        html.Append("</main><footer><span class=\"footer-brand\">WeChatExporter</span>");
+        html.Append("<span class=\"footer-dot\">·</span><span>深空霓虹主题 · 浏览器离线可阅</span></footer></body></html>");
 
         File.WriteAllText(outPath, html.ToString(), Encoding.UTF8);
         return outPath;
     }
+
+    /// <summary>与 DMG 安装界面一致的深空霓虹 HUD 样式。</summary>
+    private const string ExportStyles = """
+        :root{--cyan:#00f5ff;--purple:#7b61ff;--magenta:#ff4dd2;--green:#07ffa0;--text:#f0f8ff;--subtext:#8caad2;--glass:rgba(12,20,48,0.78);--glass-strong:rgba(8,14,36,0.92);--line:rgba(0,245,255,0.22)}
+        *{box-sizing:border-box}html{scroll-behavior:smooth}
+        body{margin:0;min-height:100vh;font-family:"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif;color:var(--text);background:linear-gradient(145deg,#080a20 0%,#120830 38%,#06122a 72%,#1c0626 100%);background-attachment:fixed;position:relative;overflow-x:hidden}
+        body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:0;opacity:.55;background-image:radial-gradient(1px 1px at 8% 14%,rgba(240,248,255,.95) 50%,transparent 51%),radial-gradient(1px 1px at 22% 38%,rgba(0,245,255,.85) 50%,transparent 51%),radial-gradient(1.5px 1.5px at 35% 8%,rgba(123,97,255,.9) 50%,transparent 51%),radial-gradient(1px 1px at 48% 62%,rgba(240,248,255,.75) 50%,transparent 51%),radial-gradient(1px 1px at 61% 24%,rgba(0,245,255,.7) 50%,transparent 51%),radial-gradient(1.5px 1.5px at 74% 72%,rgba(255,77,210,.8) 50%,transparent 51%),radial-gradient(1px 1px at 86% 18%,rgba(240,248,255,.8) 50%,transparent 51%),radial-gradient(1px 1px at 92% 48%,rgba(123,97,255,.75) 50%,transparent 51%),radial-gradient(2px 2px at 16% 82%,rgba(0,245,255,.65) 50%,transparent 51%),radial-gradient(1px 1px at 54% 88%,rgba(240,248,255,.7) 50%,transparent 51%)}
+        .bg-scene{position:fixed;inset:0;pointer-events:none;z-index:0;overflow:hidden}
+        .aurora{position:absolute;border-radius:50%;filter:blur(72px);opacity:.42;animation:drift 18s ease-in-out infinite alternate}
+        .aurora-a{width:420px;height:180px;top:-40px;left:12%;background:radial-gradient(circle,rgba(0,180,255,.55),transparent 70%)}
+        .aurora-b{width:380px;height:160px;top:60px;right:8%;background:radial-gradient(circle,rgba(140,60,255,.5),transparent 70%);animation-delay:-6s}
+        .aurora-c{width:500px;height:200px;bottom:18%;left:28%;background:radial-gradient(circle,rgba(255,60,200,.35),transparent 70%);animation-delay:-12s}
+        .grid-floor{position:absolute;left:0;right:0;bottom:0;height:42vh;background:linear-gradient(to bottom,transparent 0%,rgba(0,245,255,.04) 100%),repeating-linear-gradient(90deg,transparent,transparent 39px,rgba(0,245,255,.06) 39px,rgba(0,245,255,.06) 40px),repeating-linear-gradient(0deg,transparent,transparent 13px,rgba(123,97,255,.05) 13px,rgba(123,97,255,.05) 14px);transform:perspective(480px) rotateX(62deg);transform-origin:center bottom;mask-image:linear-gradient(to top,rgba(0,0,0,.55),transparent);opacity:.35}
+        @keyframes drift{from{transform:translate3d(-12px,0,0) scale(1)}to{transform:translate3d(18px,14px,0) scale(1.06)}}
+        header,main,footer{position:relative;z-index:1}
+        header{padding:32px 24px 28px;background:linear-gradient(180deg,rgba(12,20,48,.88),rgba(8,14,36,.72));backdrop-filter:blur(18px) saturate(140%);-webkit-backdrop-filter:blur(18px) saturate(140%);border-bottom:1px solid var(--line);box-shadow:0 12px 40px rgba(0,0,0,.35),inset 0 1px 0 rgba(255,255,255,.06)}
+        .header-glow{position:absolute;top:0;left:50%;width:min(680px,90vw);height:2px;transform:translateX(-50%);background:linear-gradient(90deg,transparent,var(--cyan),var(--purple),var(--magenta),transparent);box-shadow:0 0 24px rgba(0,245,255,.55)}
+        .eyebrow{margin:0 0 10px;font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:var(--subtext)}
+        header h1{margin:0 0 16px;font-size:clamp(24px,4vw,34px);font-weight:700;line-height:1.2;background:linear-gradient(92deg,var(--cyan) 0%,#9ae8ff 35%,var(--purple) 68%,var(--magenta) 100%);-webkit-background-clip:text;background-clip:text;color:transparent;filter:drop-shadow(0 0 18px rgba(0,245,255,.35))}
+        .stats{display:flex;flex-wrap:wrap;gap:8px}
+        .pill{display:inline-flex;align-items:center;padding:5px 12px;border-radius:999px;font-size:12px;letter-spacing:.02em;border:1px solid transparent}
+        .pill-cyan{color:var(--cyan);background:rgba(0,245,255,.1);border-color:rgba(0,245,255,.35);box-shadow:0 0 16px rgba(0,245,255,.18)}
+        .pill-purple{color:#c4b5ff;background:rgba(123,97,255,.14);border-color:rgba(123,97,255,.38);box-shadow:0 0 16px rgba(123,97,255,.18)}
+        .pill-muted{color:var(--subtext);background:rgba(140,170,210,.08);border-color:rgba(140,170,210,.22)}
+        main{max-width:880px;margin:0 auto;padding:28px 16px 56px}
+        .msg{position:relative;background:var(--glass);backdrop-filter:blur(14px) saturate(130%);-webkit-backdrop-filter:blur(14px) saturate(130%);border:1px solid rgba(123,97,255,.28);border-radius:16px;padding:16px 18px 18px;margin-bottom:14px;box-shadow:0 8px 32px rgba(0,0,0,.32),inset 0 1px 0 rgba(255,255,255,.05),0 0 24px rgba(123,97,255,.08);transition:border-color .25s ease,box-shadow .25s ease,transform .25s ease}
+        .msg::before{content:"";position:absolute;top:12px;left:12px;width:18px;height:18px;border-top:2px solid rgba(0,245,255,.55);border-left:2px solid rgba(0,245,255,.55);border-radius:4px 0 0 0;pointer-events:none}
+        .msg::after{content:"";position:absolute;bottom:12px;right:12px;width:18px;height:18px;border-bottom:2px solid rgba(123,97,255,.45);border-right:2px solid rgba(123,97,255,.45);border-radius:0 0 4px 0;pointer-events:none}
+        .msg:hover{border-color:rgba(0,245,255,.42);box-shadow:0 10px 36px rgba(0,0,0,.38),0 0 28px rgba(0,245,255,.12),inset 0 1px 0 rgba(255,255,255,.07);transform:translateY(-1px)}
+        .meta{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-bottom:10px;font-size:12px}
+        .sender{font-weight:600;color:var(--cyan);text-shadow:0 0 10px rgba(0,245,255,.45)}
+        .type{display:inline-flex;align-items:center;padding:2px 9px;border-radius:999px;font-size:11px;color:#d5c8ff;background:rgba(123,97,255,.18);border:1px solid rgba(123,97,255,.42);box-shadow:0 0 12px rgba(123,97,255,.2)}
+        .time{color:var(--subtext);margin-left:auto;font-variant-numeric:tabular-nums}
+        .text{white-space:pre-wrap;word-break:break-word;line-height:1.65;color:rgba(240,248,255,.94)}
+        .media{margin-top:12px}
+        .media img{max-width:min(100%,440px);border-radius:12px;display:block;border:1px solid rgba(0,245,255,.32);box-shadow:0 0 24px rgba(0,245,255,.18),0 8px 24px rgba(0,0,0,.35)}
+        .media video,.media audio{max-width:100%;margin-top:8px;display:block;border-radius:12px;border:1px solid rgba(123,97,255,.28);box-shadow:0 0 20px rgba(123,97,255,.15);background:var(--glass-strong)}
+        footer{text-align:center;color:var(--subtext);font-size:12px;padding:28px 16px 36px;border-top:1px solid rgba(123,97,255,.15);background:linear-gradient(180deg,transparent,rgba(8,14,36,.55))}
+        .footer-brand{color:var(--cyan);font-weight:600;text-shadow:0 0 10px rgba(0,245,255,.35)}
+        .footer-dot{margin:0 8px;opacity:.5}
+        @media (max-width:640px){header{padding:24px 16px 22px}.time{margin-left:0;width:100%}.msg{padding:14px 14px 16px}}
+        """;
 
     private static string RenderMessage(MessageRow row, string sourceDir, HashSet<string> embedded)
     {
@@ -72,7 +113,11 @@ internal static class SingleFileExporter
 
         return $"""
             <article class="msg">
-              <div class="meta"><span class="sender">{EscapeHtml(row.Sender)}</span><span class="type">{EscapeHtml(row.Type)}</span> · {EscapeHtml(row.Time)}</div>
+              <div class="meta">
+                <span class="sender">{EscapeHtml(row.Sender)}</span>
+                <span class="type">{EscapeHtml(row.Type)}</span>
+                <span class="time">{EscapeHtml(row.Time)}</span>
+              </div>
               {(showText ? $"<div class=\"text\">{content}</div>" : "")}
               {(mediaHtml.Length > 0 ? $"<div class=\"media\">{mediaHtml}</div>" : "")}
             </article>
@@ -94,7 +139,11 @@ internal static class SingleFileExporter
             if (block is null) continue;
             html.Append($"""
                 <article class="msg">
-                  <div class="meta"><span class="sender">媒体附件</span> · {EscapeHtml(Path.GetFileName(filePath))}</div>
+                  <div class="meta">
+                    <span class="sender">媒体附件</span>
+                    <span class="type">文件</span>
+                    <span class="time">{EscapeHtml(Path.GetFileName(filePath))}</span>
+                  </div>
                   <div class="media">{block}</div>
                 </article>
 

--- a/windows/WeChatExporter.Windows/WeChatExporter.Windows.csproj
+++ b/windows/WeChatExporter.Windows/WeChatExporter.Windows.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>WeChatExporter</AssemblyName>
     <RootNamespace>WeChatExporter</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
     <Company>WeChatExporter</Company>
     <Product>微信聊天记录导出</Product>
     <Description>Windows 版微信聊天记录导出工具</Description>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

将单文件 HTML 导出界面从朴素白底样式升级为与 macOS DMG 安装界面一致的**深空霓虹 HUD** 视觉风格。

## 变更内容

- **背景**：深空紫蓝渐变 + 星点 + 三层极光光晕 + 透视网格地面
- **页头**：玻璃拟态顶栏、渐变霓虹标题、消息数/内嵌媒体/时间戳胶囊标签
- **消息卡片**：玻璃拟态 + HUD 角标装饰，悬停时青色霓虹高亮
- **文字层级**：发送者青色光晕、类型紫色胶囊标签、时间戳次要色
- **媒体**：图片/音视频霓虹边框与光晕阴影
- **双平台同步**：`SingleFileExporter.swift` 与 `SingleFileExporter.cs` 样式一致

## 版本

- 版本号：`2.5.0` → `2.5.1`

## 测试

- [ ] macOS 导出 HTML，浏览器打开确认样式与 DMG 风格一致
- [ ] Windows 导出 HTML，确认样式一致
- [ ] 含图片/表情/音视频的消息卡片显示正常
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f378e-ac61-7458-af96-597774ae54d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f378e-ac61-7458-af96-597774ae54d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

