### PR TITLE
fix: 支持微信 4.1.11（issue #22）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Build app with bundled wx-cli
         run: ./build_app.sh
         env:
-          WX_CLI_VERSION: v0.7.2
+          WX_CLI_VERSION: v0.7.2-wechat411
+          WX_CLI_REPO: 93857536-pixel/wx-cli
+          FORCE_BUNDLE_WX_CLI: "1"
 
       - name: Create DMG installer
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project are documented in this file.
 
+## [2.6.3] - 2026-07-23
+
+### Fixed
+- 支持微信 **4.1.11**：内置 wx-cli 版本白名单扩展至 4.1.7–4.1.11，修复「准备数据」因版本不匹配导致的密钥捕获失败
+- 「环境检查未通过」时输出 wx-cli doctor 失败项详情，避免只看到笼统的 SIP 提示
+
+### Changed
+- 默认内置 wx-cli 改为 `93857536-pixel/wx-cli` 的 `v0.7.2-wechat411`（基于 pandorafuture/wx-cli，增加 4.1.9–4.1.11 兼容）
+
 ## [2.6.2] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 | 组件 | macOS | Windows |
 |------|-------|---------|
 | 内置 CLI | [pandorafuture/wx-cli](https://github.com/pandorafuture/wx-cli) v0.7.2 | [jackwener/wx-cli](https://github.com/jackwener/wx-cli) v0.3.0 |
-| 微信版本 | 4.x（4.1.7+ 更稳定） | 4.x（4.1.7+ 更稳定） |
+| 微信版本 | 4.x（已验证 4.1.7–4.1.11） | 4.x（4.1.7+；4.1.11 内存扫密钥可能失效） |
 
 > **隐私说明**：本工具仅在本地运行，不会上传任何聊天数据或密钥。
 

--- a/Sources/WeChatExporter/Services/WxCliService.swift
+++ b/Sources/WeChatExporter/Services/WxCliService.swift
@@ -52,9 +52,13 @@ final class WxCliService {
         try await run(["status"])
     }
 
-    func doctorOK() async -> Bool {
-        guard let output = try? await run(["doctor"]) else { return false }
-        return output.contains("All checks passed")
+    func doctorReport() async -> (ok: Bool, output: String) {
+        do {
+            let output = try await run(["doctor"], timeout: 60)
+            return (output.contains("All checks passed"), output)
+        } catch {
+            return (false, error.localizedDescription)
+        }
     }
 
     /// 密钥已保存且解密缓存可用，才适合查询会话列表。
@@ -73,8 +77,15 @@ final class WxCliService {
         tracker.reset()
         progress(tracker.estimated(message: "正在检查运行环境…"))
         log("检查运行环境…")
-        guard await doctorOK() else {
-            throw AppError.decryptFailed("wx-cli 环境检查未通过。请确认 SIP 已关闭且微信已登录。")
+        let doctor = await doctorReport()
+        if !doctor.output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            log(doctor.output)
+        }
+        guard doctor.ok else {
+            let detail = Self.summarizeDoctorFailure(doctor.output)
+            throw AppError.decryptFailed(
+                "wx-cli 环境检查未通过。\(detail)请确认：1) SIP 已关闭（csrutil status）；2) 已执行 sudo DevToolsSecurity -enable；3) 当前用户在 _developer 组；4) 微信已登录。完整日志见上方输出。"
+            )
         }
 
         progress(tracker.estimated(message: "正在读取账号状态…"))
@@ -83,11 +94,22 @@ final class WxCliService {
         if needsKey {
             progress(tracker.estimated(message: "正在捕获解密密钥（会重启微信）…"))
             log("正在捕获解密密钥（会重启微信，约 1-2 分钟）…")
-            _ = try await run(["key", "extract", "--timeout", "120"], timeout: nil, log: log, onActivity: { line in
-                if line.contains("Password") || line.contains("PBKDF2") {
-                    progress(tracker.estimated(message: "等待微信登录并捕获密钥…"))
+            do {
+                _ = try await run(["key", "extract", "--timeout", "120"], timeout: nil, log: log, onActivity: { line in
+                    if line.contains("Password") || line.contains("PBKDF2") {
+                        progress(tracker.estimated(message: "等待微信登录并捕获密钥…"))
+                    }
+                })
+            } catch {
+                let message = error.localizedDescription
+                if message.localizedCaseInsensitiveContains("not supported for key extraction")
+                    || message.localizedCaseInsensitiveContains("UnsupportedVersion") {
+                    throw AppError.decryptFailed(
+                        "当前微信版本不受内置 wx-cli 支持（需 4.1.7–4.1.11）。请升级 WeChatExporter 到最新版，或等待适配更新。原始错误：\(message)"
+                    )
                 }
-            })
+                throw error
+            }
         } else {
             log("使用已保存的密钥")
         }
@@ -545,6 +567,16 @@ final class WxCliService {
         guard line.contains("Decrypting") else { return nil }
         let digits = line.split(whereSeparator: { !$0.isNumber })
         return digits.compactMap { Int($0) }.first
+    }
+
+    private static func summarizeDoctorFailure(_ output: String) -> String {
+        let failed = output
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.hasPrefix("✗") || $0.hasPrefix("\u{2717}") || $0.lowercased().contains("failed") }
+        guard !failed.isEmpty else { return "" }
+        let joined = failed.prefix(3).joined(separator: "；")
+        return "失败项：\(joined)。"
     }
 
     private static func cleanDisplayName(_ raw: String, username: String) -> String {

--- a/build_app.sh
+++ b/build_app.sh
@@ -7,9 +7,10 @@ APP_DIR="$ROOT/${APP_NAME}.app"
 BINARY="$ROOT/.build/release/WeChatExporter"
 ICON_SRC="$ROOT/assets/AppIcon.icns"
 ICON_PNG="$ROOT/assets/AppIcon.png"
-WX_CLI_VERSION="${WX_CLI_VERSION:-v0.7.2}"
-APP_VERSION="${APP_VERSION:-2.6.2}"
-APP_BUILD="${APP_BUILD:-15}"
+WX_CLI_VERSION="${WX_CLI_VERSION:-v0.7.2-wechat411}"
+WX_CLI_REPO="${WX_CLI_REPO:-93857536-pixel/wx-cli}"
+APP_VERSION="${APP_VERSION:-2.6.3}"
+APP_BUILD="${APP_BUILD:-16}"
 
 echo "编译原生 macOS 应用…"
 cd "$ROOT"
@@ -20,7 +21,8 @@ cp "$BINARY" "$APP_DIR/Contents/MacOS/$APP_NAME"
 chmod +x "$APP_DIR/Contents/MacOS/$APP_NAME"
 
 echo "打包内置 wx-cli ${WX_CLI_VERSION}…"
-WX_CLI_VERSION="$WX_CLI_VERSION" bash "$ROOT/scripts/bundle_wx_cli.sh" "$APP_DIR/Contents/Resources"
+WX_CLI_VERSION="$WX_CLI_VERSION" WX_CLI_REPO="$WX_CLI_REPO" \
+  bash "$ROOT/scripts/bundle_wx_cli.sh" "$APP_DIR/Contents/Resources"
 chmod +x "$APP_DIR/Contents/Resources/wx-cli"
 
 bash "$ROOT/scripts/prepare_icon.sh"

--- a/scripts/bundle_wx_cli.sh
+++ b/scripts/bundle_wx_cli.sh
@@ -1,17 +1,25 @@
 #!/bin/bash
 # 下载并解压 wx-cli 到指定目录，供 WeChatExporter.app 内置使用。
+# 优先使用本地已编译二进制：LOCAL_WX_CLI=/path/to/wx-cli
 set -euo pipefail
 
 DEST_DIR="${1:?用法: bundle_wx_cli.sh <目标目录>}"
-WX_CLI_VERSION="${WX_CLI_VERSION:-v0.7.2}"
-WX_CLI_REPO="pandorafuture/wx-cli"
+WX_CLI_VERSION="${WX_CLI_VERSION:-v0.7.2-wechat411}"
+WX_CLI_REPO="${WX_CLI_REPO:-93857536-pixel/wx-cli}"
 ASSET="wx-cli-${WX_CLI_VERSION}-macos-arm64.tar.gz"
 URL="https://github.com/${WX_CLI_REPO}/releases/download/${WX_CLI_VERSION}/${ASSET}"
 
 mkdir -p "$DEST_DIR"
 DEST_BIN="$DEST_DIR/wx-cli"
 
-if [[ -x "$DEST_BIN" ]]; then
+if [[ -n "${LOCAL_WX_CLI:-}" && -x "${LOCAL_WX_CLI}" ]]; then
+  cp "${LOCAL_WX_CLI}" "$DEST_BIN"
+  chmod +x "$DEST_BIN"
+  echo "已写入本地 wx-cli：$DEST_BIN （来自 ${LOCAL_WX_CLI}）"
+  exit 0
+fi
+
+if [[ -x "$DEST_BIN" && "${FORCE_BUNDLE_WX_CLI:-0}" != "1" ]]; then
   echo "wx-cli 已存在：$DEST_BIN"
   exit 0
 fi
@@ -19,7 +27,7 @@ fi
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-echo "下载内置 wx-cli ${WX_CLI_VERSION}…"
+echo "下载内置 wx-cli ${WX_CLI_VERSION}（${WX_CLI_REPO}）…"
 curl -fsSL --retry 3 --retry-delay 2 -o "$TMP_DIR/$ASSET" "$URL"
 
 echo "解压 wx-cli…"


### PR DESCRIPTION
## Summary
- 内置 wx-cli 升级为 `93857536-pixel/wx-cli@v0.7.2-wechat411`，密钥提取版本白名单覆盖 4.1.7–4.1.11
- doctor 失败时输出具体失败项，不再只显示笼统 SIP 提示
- 版本号 bump 至 2.6.3

## Test plan
- [x] 本机微信 4.1.11：`wx-cli key extract` 通过版本检查（不再报 UnsupportedVersion）
- [x] `bundle_wx_cli.sh` 可从新 release 下载并写入二进制
- [ ] CI 打 `v2.6.3` tag 后自动产出 macOS DMG
- [ ] issue #22 报告者用 2.6.3 复测「准备数据」

Closes #22

Made with [Cursor](https://cursor.com)